### PR TITLE
TRK-003 — Container Label PDF with QR Code

### DIFF
--- a/src/main/java/com/shipping/freightops/config/AppProperties.java
+++ b/src/main/java/com/shipping/freightops/config/AppProperties.java
@@ -1,0 +1,16 @@
+package com.shipping.freightops.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "app")
+public class AppProperties {
+  private String baseUrl;
+
+  public String getBaseUrl() {
+    return baseUrl;
+  }
+
+  public void setBaseUrl(String baseUrl) {
+    this.baseUrl = baseUrl;
+  }
+}

--- a/src/main/java/com/shipping/freightops/config/GlobalExceptionHandler.java
+++ b/src/main/java/com/shipping/freightops/config/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.shipping.freightops.config;
 
 import com.shipping.freightops.exception.BadRequestException;
+import com.shipping.freightops.exception.PdfGenerationException;
 import java.time.LocalDateTime;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -54,6 +55,11 @@ public class GlobalExceptionHandler {
   @ExceptionHandler(RestClientException.class)
   public ResponseEntity<Map<String, Object>> handleRestClientException(RestClientException ex) {
     return buildError(HttpStatus.SERVICE_UNAVAILABLE, ex.getMessage());
+  }
+
+  @ExceptionHandler(PdfGenerationException.class)
+  public ResponseEntity<Map<String, Object>> handlePdfError(PdfGenerationException ex) {
+    return buildError(HttpStatus.INTERNAL_SERVER_ERROR, ex.getMessage());
   }
 
   private ResponseEntity<Map<String, Object>> buildError(HttpStatus status, String message) {

--- a/src/main/java/com/shipping/freightops/controller/ContainerController.java
+++ b/src/main/java/com/shipping/freightops/controller/ContainerController.java
@@ -31,7 +31,7 @@ public class ContainerController {
     @ApiResponse(responseCode = "404", description = "Container not found"),
     @ApiResponse(responseCode = "500", description = "Error generating PDF label")
   })
-  @GetMapping(value = "/{id}/label", produces = MediaType.APPLICATION_PDF_VALUE)
+  @GetMapping(value = "/{id}/label")
   public ResponseEntity<byte[]> getLabelForContainer(@PathVariable long id) {
     ContainerLabelResponse responseDto = containerService.generateContainerLabel(id);
 

--- a/src/main/java/com/shipping/freightops/controller/ContainerController.java
+++ b/src/main/java/com/shipping/freightops/controller/ContainerController.java
@@ -1,0 +1,45 @@
+package com.shipping.freightops.controller;
+
+import com.shipping.freightops.dto.ContainerLabelResponse;
+import com.shipping.freightops.service.ContainerService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/containers")
+public class ContainerController {
+
+  private final ContainerService containerService;
+
+  public ContainerController(ContainerService containerService) {
+    this.containerService = containerService;
+  }
+
+  @Operation(
+      summary = "Get PDF label for a container by ID",
+      description = "Returns a PDF document containing the container label")
+  @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "PDF label successfully generated"),
+    @ApiResponse(responseCode = "404", description = "Container not found"),
+    @ApiResponse(responseCode = "500", description = "Error generating PDF label")
+  })
+  @GetMapping(value = "/{id}/label", produces = MediaType.APPLICATION_PDF_VALUE)
+  public ResponseEntity<byte[]> getLabelForContainer(@PathVariable long id) {
+    ContainerLabelResponse responseDto = containerService.generateContainerLabel(id);
+
+    return ResponseEntity.ok()
+        .header(
+            HttpHeaders.CONTENT_DISPOSITION,
+            "inline; filename=\"" + responseDto.getFileName() + "\"")
+        .contentType(MediaType.APPLICATION_PDF)
+        .body(responseDto.getContent());
+  }
+}

--- a/src/main/java/com/shipping/freightops/dto/ContainerLabelResponse.java
+++ b/src/main/java/com/shipping/freightops/dto/ContainerLabelResponse.java
@@ -1,0 +1,19 @@
+package com.shipping.freightops.dto;
+
+public class ContainerLabelResponse {
+  private final byte[] content;
+  private final String fileName;
+
+  public ContainerLabelResponse(byte[] content, String fileName) {
+    this.content = content;
+    this.fileName = fileName;
+  }
+
+  public byte[] getContent() {
+    return content;
+  }
+
+  public String getFileName() {
+    return fileName;
+  }
+}

--- a/src/main/java/com/shipping/freightops/enums/ContainerSize.java
+++ b/src/main/java/com/shipping/freightops/enums/ContainerSize.java
@@ -11,4 +11,12 @@ public enum ContainerSize {
       case FORTY_FOOT -> 2;
     };
   }
+
+  // Used for PDF construction, should reflect all values in the enum
+  public String getPdfReadyValue() {
+    return switch (this) {
+      case TWENTY_FOOT -> "20ft";
+      case FORTY_FOOT -> "40ft";
+    };
+  }
 }

--- a/src/main/java/com/shipping/freightops/exception/PdfGenerationException.java
+++ b/src/main/java/com/shipping/freightops/exception/PdfGenerationException.java
@@ -1,0 +1,12 @@
+package com.shipping.freightops.exception;
+
+public class PdfGenerationException extends RuntimeException {
+
+  public PdfGenerationException(String message) {
+    super(message);
+  }
+
+  public PdfGenerationException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/src/main/java/com/shipping/freightops/repository/FreightOrderRepository.java
+++ b/src/main/java/com/shipping/freightops/repository/FreightOrderRepository.java
@@ -3,6 +3,7 @@ package com.shipping.freightops.repository;
 import com.shipping.freightops.entity.FreightOrder;
 import com.shipping.freightops.enums.OrderStatus;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -51,4 +52,7 @@ public interface FreightOrderRepository extends JpaRepository<FreightOrder, Long
     WHERE c.containerCode = :containerCode
     """)
   List<FreightOrder> findByContainerCode(@Param("containerCode") String containerCode);
+
+  Optional<FreightOrder> findFirstByContainer_ContainerCodeAndStatusOrderByVoyage_DepartureTimeAsc(
+      String containerContainerCode, OrderStatus status);
 }

--- a/src/main/java/com/shipping/freightops/service/ContainerService.java
+++ b/src/main/java/com/shipping/freightops/service/ContainerService.java
@@ -8,13 +8,14 @@ import com.shipping.freightops.config.AppProperties;
 import com.shipping.freightops.dto.ContainerLabelResponse;
 import com.shipping.freightops.entity.Container;
 import com.shipping.freightops.entity.FreightOrder;
+import com.shipping.freightops.enums.OrderStatus;
 import com.shipping.freightops.exception.PdfGenerationException;
 import com.shipping.freightops.repository.ContainerRepository;
 import com.shipping.freightops.repository.FreightOrderRepository;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.time.format.DateTimeFormatter;
-import java.util.List;
+import java.util.Optional;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -161,11 +162,13 @@ public class ContainerService {
     String arrivalPort = "-";
     String departureDate = "-";
 
-    List<FreightOrder> orders = freightOrderRepository.findByContainerCode(containerCode);
+    Optional<FreightOrder> activeOrderOpt =
+        freightOrderRepository
+            .findFirstByContainer_ContainerCodeAndStatusOrderByVoyage_DepartureTimeAsc(
+                containerCode, OrderStatus.CONFIRMED);
 
-    if (!orders.isEmpty()) {
-      FreightOrder fo = orders.getFirst();
-
+    if (activeOrderOpt.isPresent()) {
+      FreightOrder fo = activeOrderOpt.get();
       voyageNumber = fo.getVoyage().getVoyageNumber();
       vesselName = fo.getVoyage().getVessel().getName();
       departurePort = fo.getVoyage().getDeparturePort().getName();

--- a/src/main/java/com/shipping/freightops/service/ContainerService.java
+++ b/src/main/java/com/shipping/freightops/service/ContainerService.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 record ContainerLabelData(
     String containerCode,
@@ -55,6 +56,7 @@ public class ContainerService {
     this.appProperties = appProperties;
   }
 
+  @Transactional(readOnly = true)
   public ContainerLabelResponse generateContainerLabel(long containerId) {
 
     Container container = getContainer(containerId);

--- a/src/main/java/com/shipping/freightops/service/ContainerService.java
+++ b/src/main/java/com/shipping/freightops/service/ContainerService.java
@@ -1,0 +1,263 @@
+package com.shipping.freightops.service;
+
+import com.itextpdf.text.*;
+import com.itextpdf.text.pdf.PdfPCell;
+import com.itextpdf.text.pdf.PdfPTable;
+import com.itextpdf.text.pdf.PdfWriter;
+import com.shipping.freightops.config.AppProperties;
+import com.shipping.freightops.dto.ContainerLabelResponse;
+import com.shipping.freightops.entity.Container;
+import com.shipping.freightops.entity.FreightOrder;
+import com.shipping.freightops.exception.PdfGenerationException;
+import com.shipping.freightops.repository.ContainerRepository;
+import com.shipping.freightops.repository.FreightOrderRepository;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+record ContainerLabelData(
+    String containerCode,
+    String containerSize,
+    String containerType,
+    String voyageNumber,
+    String vesselName,
+    String departurePort,
+    String arrivalPort,
+    String departureDate,
+    byte[] barcode,
+    byte[] qrCode) {}
+
+@Service
+public class ContainerService {
+
+  private final BarcodeService barcodeService;
+  private final FreightOrderRepository freightOrderRepository;
+  private final ContainerRepository containerRepository;
+  private final AppProperties appProperties;
+  private static final int BARCODE_WIDTH = 300;
+  private static final int BARCODE_HEIGHT = 80;
+
+  private static final int QR_WIDTH = 250;
+  private static final int QR_HEIGHT = 250;
+
+  private static final DateTimeFormatter DATE_FMT = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+  public ContainerService(
+      BarcodeService barcodeService,
+      FreightOrderRepository freightOrderRepository,
+      ContainerRepository containerRepository,
+      AppProperties appProperties) {
+    this.barcodeService = barcodeService;
+    this.freightOrderRepository = freightOrderRepository;
+    this.containerRepository = containerRepository;
+    this.appProperties = appProperties;
+  }
+
+  public ContainerLabelResponse generateContainerLabel(long containerId) {
+
+    Container container = getContainer(containerId);
+
+    ContainerLabelData data = buildLabelData(container);
+
+    byte[] pdf = generatePdf(data);
+
+    return new ContainerLabelResponse(pdf, "container-" + data.containerCode() + "-label.pdf");
+  }
+
+  private Container getContainer(long containerId) {
+    return containerRepository
+        .findById(containerId)
+        .orElseThrow(() -> new IllegalArgumentException("Container not found: " + containerId));
+  }
+
+  private byte[] generatePdf(ContainerLabelData data) {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    try {
+
+      Document document = new Document(PageSize.A6, 20, 20, 20, 20);
+
+      PdfWriter.getInstance(document, out);
+      document.open();
+
+      Font bigBold = FontFactory.getFont(FontFactory.HELVETICA_BOLD, 18);
+      Font keys = FontFactory.getFont(FontFactory.HELVETICA, 12);
+      Font values = FontFactory.getFont(FontFactory.HELVETICA_BOLD, 14);
+      Font small = FontFactory.getFont(FontFactory.HELVETICA, 10);
+
+      addContainerHeader(document, data, bigBold);
+      addContainerSpecs(document, data, keys, values);
+      addVoyageInfo(document, data, keys, values);
+      addQrSection(document, data, small);
+
+      document.close();
+
+    } catch (DocumentException | IOException e) {
+      throw new PdfGenerationException("Failed to generate container label PDF", e);
+    }
+    return out.toByteArray();
+  }
+
+  private void addContainerHeader(Document document, ContainerLabelData data, Font title)
+      throws DocumentException, IOException {
+
+    Paragraph code = new Paragraph(data.containerCode(), title);
+    code.setAlignment(Element.ALIGN_CENTER);
+    document.add(code);
+
+    Image barcodeImage = Image.getInstance(data.barcode());
+    barcodeImage.setAlignment(Element.ALIGN_CENTER);
+    barcodeImage.scaleToFit(180, 80);
+
+    document.add(barcodeImage);
+    document.add(new Paragraph("\n"));
+  }
+
+  private void addContainerSpecs(Document document, ContainerLabelData data, Font keys, Font values)
+      throws DocumentException {
+    PdfPTable containerSpecsTable = new PdfPTable(2);
+    containerSpecsTable.setWidthPercentage(100);
+
+    // Size
+    Phrase sizePhrase = new Phrase();
+    sizePhrase.add(new Chunk("Size: ", keys));
+    sizePhrase.add(new Chunk(data.containerSize(), values));
+    PdfPCell sizeCell = new PdfPCell(sizePhrase);
+    sizeCell.setBorder(Rectangle.NO_BORDER);
+    sizeCell.setPaddingBottom(4f);
+    sizeCell.setHorizontalAlignment(Element.ALIGN_LEFT);
+
+    // Type
+    Phrase typePhrase = new Phrase();
+    typePhrase.add(new Chunk("Type: ", keys));
+    typePhrase.add(new Chunk(data.containerType(), values));
+    PdfPCell typeCell = new PdfPCell(typePhrase);
+    typeCell.setBorder(Rectangle.NO_BORDER);
+    typeCell.setPaddingBottom(4f);
+    typeCell.setHorizontalAlignment(Element.ALIGN_RIGHT);
+
+    containerSpecsTable.addCell(sizeCell);
+    containerSpecsTable.addCell(typeCell);
+
+    document.add(containerSpecsTable);
+    document.add(new Paragraph("\n"));
+  }
+
+  private ContainerLabelData buildLabelData(Container container) {
+
+    String containerCode = container.getContainerCode();
+
+    byte[] barCode = barcodeService.generateBarcode(containerCode, BARCODE_WIDTH, BARCODE_HEIGHT);
+
+    String containerSize = container.getSize().getPdfReadyValue();
+    String containerType = container.getType().toString();
+
+    String voyageNumber = "-";
+    String vesselName = "-";
+    String departurePort = "-";
+    String arrivalPort = "-";
+    String departureDate = "-";
+
+    List<FreightOrder> orders = freightOrderRepository.findByContainerCode(containerCode);
+
+    if (!orders.isEmpty()) {
+      FreightOrder fo = orders.getFirst();
+
+      voyageNumber = fo.getVoyage().getVoyageNumber();
+      vesselName = fo.getVoyage().getVessel().getName();
+      departurePort = fo.getVoyage().getDeparturePort().getName();
+      arrivalPort = fo.getVoyage().getArrivalPort().getName();
+      departureDate = fo.getVoyage().getDepartureTime().format(DATE_FMT);
+    }
+
+    String trackUrl = appProperties.getBaseUrl() + "/api/v1/track/container/" + containerCode;
+
+    byte[] qrCode = barcodeService.generateQrCode(trackUrl, QR_WIDTH, QR_HEIGHT);
+
+    return new ContainerLabelData(
+        containerCode,
+        containerSize,
+        containerType,
+        voyageNumber,
+        vesselName,
+        departurePort,
+        arrivalPort,
+        departureDate,
+        barCode,
+        qrCode);
+  }
+
+  private void addVoyageInfo(Document document, ContainerLabelData data, Font keys, Font values)
+      throws DocumentException {
+
+    PdfPTable voyageTable = new PdfPTable(1);
+    voyageTable.setWidthPercentage(100);
+
+    // Voyage
+    Phrase voyagePhrase = new Phrase();
+    voyagePhrase.add(new Chunk("Voyage: ", keys));
+    voyagePhrase.add(new Chunk(data.voyageNumber(), values));
+    PdfPCell voyageCell = new PdfPCell(voyagePhrase);
+    voyageCell.setBorder(Rectangle.NO_BORDER);
+    voyageCell.setPaddingBottom(4f);
+    voyageTable.addCell(voyageCell);
+
+    // Vessel
+    Phrase vesselPhrase = new Phrase();
+    vesselPhrase.add(new Chunk("Vessel: ", keys));
+    vesselPhrase.add(new Chunk(data.vesselName(), values));
+    PdfPCell vesselCell = new PdfPCell(vesselPhrase);
+    vesselCell.setBorder(Rectangle.NO_BORDER);
+    vesselCell.setPaddingBottom(4f);
+    voyageTable.addCell(vesselCell);
+
+    // Route
+    Phrase routePhrase = new Phrase();
+    routePhrase.add(new Chunk(data.departurePort(), values));
+    routePhrase.add(new Chunk(" -> ", keys));
+    routePhrase.add(new Chunk(data.arrivalPort(), values));
+    PdfPCell routeCell = new PdfPCell(routePhrase);
+    routeCell.setBorder(Rectangle.NO_BORDER);
+    routeCell.setPaddingBottom(4f);
+    voyageTable.addCell(routeCell);
+
+    // Departure
+    Phrase depPhrase = new Phrase();
+    depPhrase.add(new Chunk("Departure: ", keys));
+    depPhrase.add(new Chunk(data.departureDate(), values));
+    PdfPCell depCell = new PdfPCell(depPhrase);
+    depCell.setBorder(Rectangle.NO_BORDER);
+    depCell.setPaddingBottom(4f);
+    voyageTable.addCell(depCell);
+
+    document.add(voyageTable);
+    document.add(new Paragraph("\n"));
+  }
+
+  private void addQrSection(Document document, ContainerLabelData data, Font small)
+      throws DocumentException, IOException {
+
+    PdfPTable qrTable = new PdfPTable(new float[] {1, 1});
+    qrTable.setWidthPercentage(100);
+
+    Image qrImage = Image.getInstance(data.qrCode());
+    qrImage.scaleToFit(120, 120);
+    qrImage.setBorder(Rectangle.NO_BORDER);
+
+    PdfPCell qrCell = new PdfPCell(qrImage);
+    qrCell.setBorder(Rectangle.NO_BORDER);
+    qrCell.setHorizontalAlignment(Element.ALIGN_LEFT);
+    qrCell.setVerticalAlignment(Element.ALIGN_BOTTOM);
+    qrTable.addCell(qrCell);
+
+    PdfPCell textCell = new PdfPCell(new Phrase("Scan to track", small));
+    textCell.setBorder(Rectangle.NO_BORDER);
+    textCell.setHorizontalAlignment(Element.ALIGN_LEFT);
+    textCell.setVerticalAlignment(Element.ALIGN_MIDDLE);
+    textCell.setPaddingLeft(10f);
+    qrTable.addCell(textCell);
+
+    document.add(qrTable);
+  }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,10 +14,8 @@ spring.sql.init.mode=always
 spring.jpa.defer-datasource-initialization=true
 # ── Jackson ──
 spring.jackson.serialization.write-dates-as-timestamps=false
-
 # Booking settings
 app.booking.auto-cutoff-percent=95
-
 # AI
 app.ai.provider=noop
 app.ai.api-key=${AI_API_KEY}
@@ -27,3 +25,5 @@ app.ai.base-url=https://api.anthropic.com
 app.ai.connect-timeout=30
 app.ai.anthropic-version=2023-06-01
 app.ai.test.enabled=true
+# Base url
+app.base-url=http://localhost:8080

--- a/src/test/java/com/shipping/freightops/controller/ContainerControllerTest.java
+++ b/src/test/java/com/shipping/freightops/controller/ContainerControllerTest.java
@@ -5,11 +5,17 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.shipping.freightops.entity.Container;
+import com.shipping.freightops.entity.*;
+import com.shipping.freightops.enums.AgentType;
 import com.shipping.freightops.enums.ContainerSize;
 import com.shipping.freightops.enums.ContainerType;
-import com.shipping.freightops.repository.ContainerRepository;
-import com.shipping.freightops.service.ContainerService;
+import com.shipping.freightops.enums.OrderStatus;
+import com.shipping.freightops.repository.*;
+import java.math.BigDecimal;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.LocalDateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,25 +24,106 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@Transactional
 public class ContainerControllerTest {
   @Autowired private MockMvc mockMvc;
-  @Autowired private ContainerService containerService;
   @Autowired private ContainerRepository containerRepository;
+  @Autowired private VoyageRepository voyageRepository;
+  @Autowired private VesselRepository vesselRepository;
+  @Autowired private PortRepository portRepository;
+  @Autowired private FreightOrderRepository freightOrderRepository;
+  @Autowired private CustomerRepository customerRepository;
+  @Autowired private AgentRepository agentRepository;
 
   private Container savedContainer;
+  private Voyage activeVoyage;
+  private Voyage historicalVoyage;
+  private Customer savedCustomer;
+  private Agent savedAgent;
 
   @BeforeEach
   void setUp() {
+
+    // Container
     savedContainer =
         containerRepository.save(
             new Container("TSTU1234567", ContainerSize.TWENTY_FOOT, ContainerType.DRY));
+
+    // Ports
+    Port departure = portRepository.save(new Port("AEJEA", "Jebel Ali", "UAE"));
+    Port arrival = portRepository.save(new Port("CNSHA", "Shanghai", "China"));
+
+    // Vessels
+    Vessel vessel1 = vesselRepository.save(new Vessel("MV Active", "V001", 1000));
+    Vessel vessel2 = vesselRepository.save(new Vessel("MV History", "V002", 1000));
+
+    // Voyages
+    Voyage activeVoyageObj = new Voyage();
+    activeVoyageObj.setVoyageNumber("VOY-ACTIVE");
+    activeVoyageObj.setVessel(vessel1);
+    activeVoyageObj.setDeparturePort(departure);
+    activeVoyageObj.setArrivalPort(arrival);
+    activeVoyageObj.setMaxCapacityTeu(3000);
+    activeVoyageObj.setDepartureTime(LocalDateTime.now().plusDays(1));
+    activeVoyageObj.setArrivalTime(LocalDateTime.now().plusDays(10));
+    activeVoyage = voyageRepository.save(activeVoyageObj);
+
+    Voyage historicalVoyage = new Voyage();
+    historicalVoyage.setVoyageNumber("VOY-HIST");
+    historicalVoyage.setVessel(vessel2);
+    historicalVoyage.setDeparturePort(departure);
+    historicalVoyage.setArrivalPort(arrival);
+    historicalVoyage.setMaxCapacityTeu(3000);
+    historicalVoyage.setDepartureTime(LocalDateTime.now().minusDays(10));
+    historicalVoyage.setArrivalTime(LocalDateTime.now().minusDays(5));
+    historicalVoyage = voyageRepository.save(historicalVoyage);
+
+    // Customer
+    Customer customer = new Customer();
+    customer.setCompanyName("Test Customer Inc.");
+    customer.setContactName("John Doe");
+    customer.setEmail("john@example.com");
+    savedCustomer = customerRepository.save(customer);
+
+    // Agent
+    Agent agent = new Agent();
+    agent.setName("Test Agent");
+    agent.setEmail("agent@example.com");
+    agent.setCommissionPercent(BigDecimal.valueOf(5));
+    agent.setType(AgentType.EXTERNAL);
+    savedAgent = agentRepository.save(agent);
+
+    // FreightOrder (historical)
+    FreightOrder historicalOrder = new FreightOrder();
+    historicalOrder.setContainer(savedContainer);
+    historicalOrder.setVoyage(historicalVoyage);
+    historicalOrder.setCustomer(savedCustomer);
+    historicalOrder.setAgent(savedAgent);
+    historicalOrder.setStatus(OrderStatus.DELIVERED);
+    historicalOrder.setOrderedBy("ops-team");
+    historicalOrder.setBasePriceUsd(BigDecimal.valueOf(900));
+    historicalOrder.setFinalPrice(BigDecimal.valueOf(950));
+    freightOrderRepository.save(historicalOrder);
+
+    // FreightOrder (active)
+    FreightOrder activeOrder = new FreightOrder();
+    activeOrder.setContainer(savedContainer);
+    activeOrder.setVoyage(activeVoyage);
+    activeOrder.setCustomer(savedCustomer);
+    activeOrder.setAgent(savedAgent);
+    activeOrder.setStatus(OrderStatus.CONFIRMED);
+    activeOrder.setOrderedBy("ops-team");
+    activeOrder.setBasePriceUsd(BigDecimal.valueOf(1000));
+    activeOrder.setFinalPrice(BigDecimal.valueOf(1100));
+    freightOrderRepository.save(activeOrder);
   }
 
   @Test
-  @DisplayName("GET /api/v1/containers/{id}/label → returns valid PDF")
+  @DisplayName("GET /api/v1/containers/{id}/label → returns valid PDF with voyage info")
   void getContainerLabel_returnsValidPdf() throws Exception {
 
     mockMvc
@@ -48,6 +135,11 @@ public class ContainerControllerTest {
               byte[] bytes = result.getResponse().getContentAsByteArray();
               String header = new String(bytes, 0, 4);
               assertEquals("%PDF", header);
+
+              // Pls verify pdf manually
+              Path file = Paths.get("target/test-container-label.pdf");
+              Files.write(file, bytes);
+              System.out.println("PDF saved to: " + file.toAbsolutePath());
             });
   }
 }

--- a/src/test/java/com/shipping/freightops/controller/ContainerControllerTest.java
+++ b/src/test/java/com/shipping/freightops/controller/ContainerControllerTest.java
@@ -1,0 +1,53 @@
+package com.shipping.freightops.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.shipping.freightops.entity.Container;
+import com.shipping.freightops.enums.ContainerSize;
+import com.shipping.freightops.enums.ContainerType;
+import com.shipping.freightops.repository.ContainerRepository;
+import com.shipping.freightops.service.ContainerService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class ContainerControllerTest {
+  @Autowired private MockMvc mockMvc;
+  @Autowired private ContainerService containerService;
+  @Autowired private ContainerRepository containerRepository;
+
+  private Container savedContainer;
+
+  @BeforeEach
+  void setUp() {
+    savedContainer =
+        containerRepository.save(
+            new Container("TSTU1234567", ContainerSize.TWENTY_FOOT, ContainerType.DRY));
+  }
+
+  @Test
+  @DisplayName("GET /api/v1/containers/{id}/label → returns valid PDF")
+  void getContainerLabel_returnsValidPdf() throws Exception {
+
+    mockMvc
+        .perform(get("/api/v1/containers/{id}/label", savedContainer.getId()))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_PDF))
+        .andExpect(
+            result -> {
+              byte[] bytes = result.getResponse().getContentAsByteArray();
+              String header = new String(bytes, 0, 4);
+              assertEquals("%PDF", header);
+            });
+  }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -13,3 +13,5 @@ app.booking.auto-cutoff-percent=95
 app.ai.provider=noop
 app.ai.connect-timeout=30
 app.ai.test.enabled=true
+# Base url
+app.base-url=http://localhost:8080


### PR DESCRIPTION
# 🚀 Pull Request

## 📌 Summary
Added a new endpoint to generate a PDF file for a container. By default, the endpoint returns the file **inline**, so a browser opens it instead of downloading automatically.  

Fields for voyage, vessel, etc., are **always displayed**, even if the container is not associated with any voyage or vessel.  

⚠️ Known issue (reported in #57): if a container **does not have any orders**, the tracking URL encoded in the QR code will return **404 Not Found**.


## ✅ Checklist
- [x] PDF generates with barcode and QR code
- [x] QR code encodes the correct tracking URL
- [x] Voyage info shown if container is on an active booking
- [x] Label works without active booking (shows container info only)
- [x] Test verifies 200 response with application/pdf content type
- [x] Code is formatted

## 🔗 Related Issues
Closes #31 