### PR TITLE
FIX: return 200 when container exists but has no orders 

### DIFF
--- a/src/main/java/com/shipping/freightops/controller/TrackingController.java
+++ b/src/main/java/com/shipping/freightops/controller/TrackingController.java
@@ -4,7 +4,6 @@ import com.shipping.freightops.dto.ContainerTrackingResponse;
 import com.shipping.freightops.dto.OrderTrackingResponse;
 import com.shipping.freightops.entity.FreightOrder;
 import com.shipping.freightops.service.TrackingService;
-import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -30,7 +29,6 @@ public class TrackingController {
   @GetMapping("/container/{containerCode}")
   public ResponseEntity<ContainerTrackingResponse> trackContainer(
       @PathVariable String containerCode) {
-    List<FreightOrder> orders = trackingService.trackContainer(containerCode);
-    return ResponseEntity.ok(ContainerTrackingResponse.fromEntities(orders));
+    return ResponseEntity.ok(trackingService.trackContainer(containerCode));
   }
 }

--- a/src/main/java/com/shipping/freightops/dto/ContainerTrackingResponse.java
+++ b/src/main/java/com/shipping/freightops/dto/ContainerTrackingResponse.java
@@ -1,9 +1,11 @@
 package com.shipping.freightops.dto;
 
+import com.shipping.freightops.entity.Container;
 import com.shipping.freightops.entity.FreightOrder;
 import com.shipping.freightops.enums.ContainerSize;
 import com.shipping.freightops.enums.ContainerType;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class ContainerTrackingResponse {
@@ -11,6 +13,17 @@ public class ContainerTrackingResponse {
   private ContainerSize containerSize;
   private ContainerType containerType;
   private List<VoyageTrackingResponse> voyages;
+
+  /** Creates a response for a container with no associated orders. */
+  public static ContainerTrackingResponse fromContainer(Container container) {
+    if (container == null) return null;
+    ContainerTrackingResponse dto = new ContainerTrackingResponse();
+    dto.containerCode = container.getContainerCode();
+    dto.containerSize = container.getSize();
+    dto.containerType = container.getType();
+    dto.voyages = Collections.emptyList();
+    return dto;
+  }
 
   public static ContainerTrackingResponse fromEntities(List<FreightOrder> orders) {
     if (orders == null || orders.isEmpty()) return null;

--- a/src/main/java/com/shipping/freightops/service/TrackingService.java
+++ b/src/main/java/com/shipping/freightops/service/TrackingService.java
@@ -1,6 +1,9 @@
 package com.shipping.freightops.service;
 
+import com.shipping.freightops.dto.ContainerTrackingResponse;
+import com.shipping.freightops.entity.Container;
 import com.shipping.freightops.entity.FreightOrder;
+import com.shipping.freightops.repository.ContainerRepository;
 import com.shipping.freightops.repository.FreightOrderRepository;
 import java.util.List;
 import org.springframework.stereotype.Service;
@@ -10,9 +13,12 @@ import org.springframework.transaction.annotation.Transactional;
 public class TrackingService {
 
   private final FreightOrderRepository orderRepository;
+  private final ContainerRepository containerRepository;
 
-  public TrackingService(FreightOrderRepository orderRepository) {
+  public TrackingService(
+      FreightOrderRepository orderRepository, ContainerRepository containerRepository) {
     this.orderRepository = orderRepository;
+    this.containerRepository = containerRepository;
   }
 
   @Transactional(readOnly = true)
@@ -23,10 +29,17 @@ public class TrackingService {
   }
 
   @Transactional(readOnly = true)
-  public List<FreightOrder> trackContainer(String containerCode) {
+  public ContainerTrackingResponse trackContainer(String containerCode) {
+    Container container =
+        containerRepository
+            .findByContainerCode(containerCode)
+            .orElseThrow(
+                () -> new IllegalArgumentException("Container not found: " + containerCode));
+
     List<FreightOrder> orders = orderRepository.findByContainerCode(containerCode);
-    if (orders.isEmpty())
-      throw new IllegalArgumentException("Container not found: " + containerCode);
-    return orders;
+    if (orders.isEmpty()) {
+      return ContainerTrackingResponse.fromContainer(container);
+    }
+    return ContainerTrackingResponse.fromEntities(orders);
   }
 }

--- a/src/test/java/com/shipping/freightops/controller/TrackingControllerTest.java
+++ b/src/test/java/com/shipping/freightops/controller/TrackingControllerTest.java
@@ -136,4 +136,22 @@ public class TrackingControllerTest {
   void testTrackContainer_nonExistentCode_returnsNotFound() throws Exception {
     mockMvc.perform(get("/api/v1/track/container/UNKNOWN")).andExpect(status().isNotFound());
   }
+
+  @Test
+  @DisplayName(
+      "GET /api/v1/track/container/{containerCode} - container with no orders returns 200 with empty voyages")
+  void testTrackContainer_containerWithNoOrders_returnsOkWithEmptyVoyages() throws Exception {
+    containerRepository.save(
+        new Container("ORPHAN-001", ContainerSize.TWENTY_FOOT, ContainerType.DRY));
+    freightOrderRepository.deleteAll();
+
+    mockMvc
+        .perform(get("/api/v1/track/container/ORPHAN-001"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.containerCode").value("ORPHAN-001"))
+        .andExpect(jsonPath("$.containerSize").value("TWENTY_FOOT"))
+        .andExpect(jsonPath("$.containerType").value("DRY"))
+        .andExpect(jsonPath("$.voyages").isArray())
+        .andExpect(jsonPath("$.voyages").isEmpty());
+  }
 }


### PR DESCRIPTION
## Fix: Return 200 with empty voyages when container has no orders

### Changes
- Updated `TrackingService` to validate container existence via `ContainerRepository`
- Added `ContainerTrackingResponse.fromContainer` for the empty-orders case
- Simplified `TrackingController` to return the service response directly
- Added a test covering a container with no associated orders

### Verification
```bash
mvn clean verify   
mvn fmt:check  
```
Close #57 