### PR TITLE
ENH-005 — Introduce Lombok across all entities and DTOs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,29 @@
+# Claude Working Instructions
+
+## Default Workflow
+
+### 1. Think before acting
+When the user raises a topic or problem, **think and plan first**. Do not immediately write code.
+
+### 2. Create a ticket, not a fix
+Unless the request is marked **urgent**, respond by:
+- Briefly describing the problem and root cause
+- Drafting a ticket in `docs/ISSUES-PHASE3.md` (or the appropriate phase file) following the existing format
+- Stopping there — do not implement
+
+### 3. Get approval before implementing
+When ready to implement a ticket (urgent or approved), **brief the solution first**:
+- What will change (files, entities, queries, tests)
+- Any trade-offs or risks
+- Wait for explicit approval before writing code
+
+### 4. Test-driven development
+Once approved, write **failing tests first** — only the tests necessary to prove correctness of the specific change, no more. Then implement until they pass.
+
+---
+
+## What counts as urgent
+The user explicitly says: "do it now", "fix this", "urgent", or pastes a live error trace expecting an immediate fix.
+
+## Ticket format
+Follow the structure in `docs/ISSUES-PHASE3.md`: description paragraph, named sections, `**Acceptance criteria:**` checklist.

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,13 @@
             <optional>true</optional>
         </dependency>
 
+        <!-- Lombok -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <optional>true</optional>
+        </dependency>
+
         <!-- Test -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/shipping/freightops/dto/AddVesselOwnerRequest.java
+++ b/src/main/java/com/shipping/freightops/dto/AddVesselOwnerRequest.java
@@ -6,8 +6,14 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.math.BigDecimal;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 /** Payload for adding a new owner to a vessel. */
+@Getter
+@Setter
+@NoArgsConstructor
 public class AddVesselOwnerRequest {
 
   @NotBlank(message = "Owner name is required")
@@ -21,28 +27,4 @@ public class AddVesselOwnerRequest {
   @DecimalMin(value = "0.01", message = "Share percent must be greater than 0")
   @DecimalMax(value = "100.00", message = "Share percent must not exceed 100")
   private BigDecimal sharePercent;
-
-  public String getOwnerName() {
-    return ownerName;
-  }
-
-  public void setOwnerName(String ownerName) {
-    this.ownerName = ownerName;
-  }
-
-  public String getOwnerEmail() {
-    return ownerEmail;
-  }
-
-  public void setOwnerEmail(String ownerEmail) {
-    this.ownerEmail = ownerEmail;
-  }
-
-  public BigDecimal getSharePercent() {
-    return sharePercent;
-  }
-
-  public void setSharePercent(BigDecimal sharePercent) {
-    this.sharePercent = sharePercent;
-  }
 }

--- a/src/main/java/com/shipping/freightops/dto/AgentCreateRequest.java
+++ b/src/main/java/com/shipping/freightops/dto/AgentCreateRequest.java
@@ -3,7 +3,13 @@ package com.shipping.freightops.dto;
 import com.shipping.freightops.enums.AgentType;
 import jakarta.validation.constraints.*;
 import java.math.BigDecimal;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+@Getter
+@Setter
+@NoArgsConstructor
 public class AgentCreateRequest {
 
   @NotBlank private String name;
@@ -16,36 +22,4 @@ public class AgentCreateRequest {
   private BigDecimal commissionPercent;
 
   @NotNull private AgentType type;
-
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  public String getEmail() {
-    return email;
-  }
-
-  public void setEmail(String email) {
-    this.email = email;
-  }
-
-  public BigDecimal getCommissionPercent() {
-    return commissionPercent;
-  }
-
-  public void setCommissionPercent(BigDecimal commissionPercent) {
-    this.commissionPercent = commissionPercent;
-  }
-
-  public AgentType getType() {
-    return type;
-  }
-
-  public void setType(AgentType type) {
-    this.type = type;
-  }
 }

--- a/src/main/java/com/shipping/freightops/dto/AgentResponse.java
+++ b/src/main/java/com/shipping/freightops/dto/AgentResponse.java
@@ -3,7 +3,13 @@ package com.shipping.freightops.dto;
 import com.shipping.freightops.enums.AgentType;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+@Getter
+@Setter
+@NoArgsConstructor
 public class AgentResponse {
 
   private Long id;
@@ -14,68 +20,4 @@ public class AgentResponse {
   private boolean active;
   private LocalDateTime createdAt;
   private LocalDateTime updatedAt;
-
-  public Long getId() {
-    return id;
-  }
-
-  public void setId(Long id) {
-    this.id = id;
-  }
-
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  public String getEmail() {
-    return email;
-  }
-
-  public void setEmail(String email) {
-    this.email = email;
-  }
-
-  public BigDecimal getCommissionPercent() {
-    return commissionPercent;
-  }
-
-  public void setCommissionPercent(BigDecimal commissionPercent) {
-    this.commissionPercent = commissionPercent;
-  }
-
-  public AgentType getType() {
-    return type;
-  }
-
-  public void setType(AgentType type) {
-    this.type = type;
-  }
-
-  public boolean isActive() {
-    return active;
-  }
-
-  public void setActive(boolean active) {
-    this.active = active;
-  }
-
-  public LocalDateTime getCreatedAt() {
-    return createdAt;
-  }
-
-  public void setCreatedAt(LocalDateTime createdAt) {
-    this.createdAt = createdAt;
-  }
-
-  public LocalDateTime getUpdatedAt() {
-    return updatedAt;
-  }
-
-  public void setUpdatedAt(LocalDateTime updatedAt) {
-    this.updatedAt = updatedAt;
-  }
 }

--- a/src/main/java/com/shipping/freightops/dto/AgentUpdateRequest.java
+++ b/src/main/java/com/shipping/freightops/dto/AgentUpdateRequest.java
@@ -3,7 +3,13 @@ package com.shipping.freightops.dto;
 import jakarta.validation.constraints.DecimalMax;
 import jakarta.validation.constraints.DecimalMin;
 import java.math.BigDecimal;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+@Getter
+@Setter
+@NoArgsConstructor
 public class AgentUpdateRequest {
 
   @DecimalMin("0.0")
@@ -11,20 +17,4 @@ public class AgentUpdateRequest {
   private BigDecimal commissionPercent;
 
   private Boolean active;
-
-  public BigDecimal getCommissionPercent() {
-    return commissionPercent;
-  }
-
-  public void setCommissionPercent(BigDecimal commissionPercent) {
-    this.commissionPercent = commissionPercent;
-  }
-
-  public Boolean getActive() {
-    return active;
-  }
-
-  public void setActive(Boolean active) {
-    this.active = active;
-  }
 }

--- a/src/main/java/com/shipping/freightops/dto/BookingStatusUpdateRequest.java
+++ b/src/main/java/com/shipping/freightops/dto/BookingStatusUpdateRequest.java
@@ -1,16 +1,14 @@
 package com.shipping.freightops.dto;
 
 import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+@Getter
+@Setter
+@NoArgsConstructor
 public class BookingStatusUpdateRequest {
 
   @NotNull private boolean bookingOpen;
-
-  public boolean isBookingOpen() {
-    return bookingOpen;
-  }
-
-  public void setBookingOpen(boolean bookingOpen) {
-    this.bookingOpen = bookingOpen;
-  }
 }

--- a/src/main/java/com/shipping/freightops/dto/ContainerLabelResponse.java
+++ b/src/main/java/com/shipping/freightops/dto/ContainerLabelResponse.java
@@ -1,5 +1,10 @@
 package com.shipping.freightops.dto;
 
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
 public class ContainerLabelResponse {
   private final byte[] content;
   private final String fileName;
@@ -7,13 +12,5 @@ public class ContainerLabelResponse {
   public ContainerLabelResponse(byte[] content, String fileName) {
     this.content = content;
     this.fileName = fileName;
-  }
-
-  public byte[] getContent() {
-    return content;
-  }
-
-  public String getFileName() {
-    return fileName;
   }
 }

--- a/src/main/java/com/shipping/freightops/dto/ContainerResponse.java
+++ b/src/main/java/com/shipping/freightops/dto/ContainerResponse.java
@@ -4,8 +4,14 @@ import com.shipping.freightops.entity.Container;
 import com.shipping.freightops.enums.ContainerSize;
 import com.shipping.freightops.enums.ContainerType;
 import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 /** Read-only view of a container returned by the API. */
+@Getter
+@Setter
+@NoArgsConstructor
 public class ContainerResponse {
 
   private Long id;
@@ -25,29 +31,5 @@ public class ContainerResponse {
     dto.teu = container.getTeu();
     dto.createdAt = container.getCreatedAt();
     return dto;
-  }
-
-  public Long getId() {
-    return id;
-  }
-
-  public String getContainerCode() {
-    return containerCode;
-  }
-
-  public ContainerSize getSize() {
-    return size;
-  }
-
-  public ContainerType getType() {
-    return type;
-  }
-
-  public int getTeu() {
-    return teu;
-  }
-
-  public LocalDateTime getCreatedAt() {
-    return createdAt;
   }
 }

--- a/src/main/java/com/shipping/freightops/dto/ContainerTrackingResponse.java
+++ b/src/main/java/com/shipping/freightops/dto/ContainerTrackingResponse.java
@@ -7,7 +7,13 @@ import com.shipping.freightops.enums.ContainerType;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+@Getter
+@Setter
+@NoArgsConstructor
 public class ContainerTrackingResponse {
   private String containerCode;
   private ContainerSize containerSize;
@@ -41,21 +47,5 @@ public class ContainerTrackingResponse {
     dto.voyages.sort((v1, v2) -> v1.getDepartureTime().compareTo(v2.getDepartureTime()));
 
     return dto;
-  }
-
-  public String getContainerCode() {
-    return containerCode;
-  }
-
-  public ContainerSize getContainerSize() {
-    return containerSize;
-  }
-
-  public ContainerType getContainerType() {
-    return containerType;
-  }
-
-  public List<VoyageTrackingResponse> getVoyages() {
-    return voyages;
   }
 }

--- a/src/main/java/com/shipping/freightops/dto/CreateContainerRequest.java
+++ b/src/main/java/com/shipping/freightops/dto/CreateContainerRequest.java
@@ -5,7 +5,13 @@ import com.shipping.freightops.enums.ContainerType;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+@Getter
+@Setter
+@NoArgsConstructor
 public class CreateContainerRequest {
 
   @NotBlank(message = "Container code is required")
@@ -19,28 +25,4 @@ public class CreateContainerRequest {
   /** Must be one of: DRY, REEFER, OPEN_TOP, FLAT_RACK, TANK. */
   @NotNull(message = "Container type is required")
   private ContainerType type;
-
-  public String getContainerCode() {
-    return containerCode;
-  }
-
-  public void setContainerCode(String containerCode) {
-    this.containerCode = containerCode;
-  }
-
-  public ContainerSize getSize() {
-    return size;
-  }
-
-  public void setSize(ContainerSize size) {
-    this.size = size;
-  }
-
-  public ContainerType getType() {
-    return type;
-  }
-
-  public void setType(ContainerType type) {
-    this.type = type;
-  }
 }

--- a/src/main/java/com/shipping/freightops/dto/CreateCustomerRequest.java
+++ b/src/main/java/com/shipping/freightops/dto/CreateCustomerRequest.java
@@ -3,7 +3,13 @@ package com.shipping.freightops.dto;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+@Getter
+@Setter
+@NoArgsConstructor
 public class CreateCustomerRequest {
 
   @NotBlank(message = "Company name is required")
@@ -20,44 +26,4 @@ public class CreateCustomerRequest {
   private String phone;
 
   private String address;
-
-  public String getCompanyName() {
-    return companyName;
-  }
-
-  public void setCompanyName(String companyName) {
-    this.companyName = companyName;
-  }
-
-  public String getContactName() {
-    return contactName;
-  }
-
-  public void setContactName(String contactName) {
-    this.contactName = contactName;
-  }
-
-  public String getPhone() {
-    return phone;
-  }
-
-  public void setPhone(String phone) {
-    this.phone = phone;
-  }
-
-  public String getEmail() {
-    return email;
-  }
-
-  public void setEmail(String email) {
-    this.email = email;
-  }
-
-  public String getAddress() {
-    return address;
-  }
-
-  public void setAddress(String address) {
-    this.address = address;
-  }
 }

--- a/src/main/java/com/shipping/freightops/dto/CreateFreightOrderRequest.java
+++ b/src/main/java/com/shipping/freightops/dto/CreateFreightOrderRequest.java
@@ -5,8 +5,12 @@ import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.math.BigDecimal;
+import lombok.Getter;
+import lombok.Setter;
 
 /** Payload for creating a new freight order. */
+@Getter
+@Setter
 public class CreateFreightOrderRequest {
 
   @NotNull(message = "Voyage ID is required")
@@ -29,60 +33,4 @@ public class CreateFreightOrderRequest {
   @DecimalMax(value = "100", inclusive = true)
   @DecimalMin(value = "0", inclusive = true)
   private BigDecimal discountPercent;
-
-  public Long getVoyageId() {
-    return voyageId;
-  }
-
-  public void setVoyageId(Long voyageId) {
-    this.voyageId = voyageId;
-  }
-
-  public Long getContainerId() {
-    return containerId;
-  }
-
-  public void setContainerId(Long containerId) {
-    this.containerId = containerId;
-  }
-
-  public Long getAgentId() {
-    return agentId;
-  }
-
-  public void setAgentId(Long agentId) {
-    this.agentId = agentId;
-  }
-
-  public Long getCustomerId() {
-    return customerId;
-  }
-
-  public void setCustomerId(Long customerId) {
-    this.customerId = customerId;
-  }
-
-  public String getOrderedBy() {
-    return orderedBy;
-  }
-
-  public void setOrderedBy(String orderedBy) {
-    this.orderedBy = orderedBy;
-  }
-
-  public String getNotes() {
-    return notes;
-  }
-
-  public void setNotes(String notes) {
-    this.notes = notes;
-  }
-
-  public BigDecimal getDiscountPercent() {
-    return discountPercent;
-  }
-
-  public void setDiscountPercent(BigDecimal discountPercent) {
-    this.discountPercent = discountPercent;
-  }
 }

--- a/src/main/java/com/shipping/freightops/dto/CreatePortRequest.java
+++ b/src/main/java/com/shipping/freightops/dto/CreatePortRequest.java
@@ -2,8 +2,14 @@ package com.shipping.freightops.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 /** Payload for creating a new port. */
+@Getter
+@Setter
+@NoArgsConstructor
 public class CreatePortRequest {
 
   @NotBlank(message = "unlocode is required")
@@ -15,28 +21,4 @@ public class CreatePortRequest {
 
   @NotBlank(message = "country is required")
   private String country;
-
-  public String getUnlocode() {
-    return unlocode;
-  }
-
-  public void setUnlocode(String unlocode) {
-    this.unlocode = unlocode;
-  }
-
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  public String getCountry() {
-    return country;
-  }
-
-  public void setCountry(String country) {
-    this.country = country;
-  }
 }

--- a/src/main/java/com/shipping/freightops/dto/CreateVesselRequest.java
+++ b/src/main/java/com/shipping/freightops/dto/CreateVesselRequest.java
@@ -4,8 +4,14 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Positive;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 /** Payload for creating a new vessel. */
+@Getter
+@Setter
+@NoArgsConstructor
 public class CreateVesselRequest {
 
   @NotBlank(message = "Vessel name is required")
@@ -18,28 +24,4 @@ public class CreateVesselRequest {
   @NotNull(message = "Vessel capacityTeu is required")
   @Positive(message = "Vessel capacityTeu must be greater than 0")
   private int capacityTeu;
-
-  public String getName() {
-    return name;
-  }
-
-  public String getImoNumber() {
-    return imoNumber;
-  }
-
-  public int getCapacityTeu() {
-    return capacityTeu;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  public void setImoNumber(String imoNumber) {
-    this.imoNumber = imoNumber;
-  }
-
-  public void setCapacityTeu(int capacityTeu) {
-    this.capacityTeu = capacityTeu;
-  }
 }

--- a/src/main/java/com/shipping/freightops/dto/CreateVoyageCostRequest.java
+++ b/src/main/java/com/shipping/freightops/dto/CreateVoyageCostRequest.java
@@ -4,25 +4,15 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import java.math.BigDecimal;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+@Getter
+@Setter
+@NoArgsConstructor
 public class CreateVoyageCostRequest {
   @NotBlank private String description;
 
   @NotNull @Positive private BigDecimal amountUsd;
-
-  public String getDescription() {
-    return description;
-  }
-
-  public void setDescription(String description) {
-    this.description = description;
-  }
-
-  public BigDecimal getAmountUsd() {
-    return amountUsd;
-  }
-
-  public void setAmountUsd(BigDecimal amountUsd) {
-    this.amountUsd = amountUsd;
-  }
 }

--- a/src/main/java/com/shipping/freightops/dto/CreateVoyageRequest.java
+++ b/src/main/java/com/shipping/freightops/dto/CreateVoyageRequest.java
@@ -4,8 +4,14 @@ import com.shipping.freightops.enums.VoyageStatus;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 // payload for creation new voyage
+@Getter
+@Setter
+@NoArgsConstructor
 public class CreateVoyageRequest {
   @NotBlank private String voyageNumber;
 
@@ -42,63 +48,5 @@ public class CreateVoyageRequest {
     this.departureTime = departureTime;
     this.arrivalTime = arrivalTime;
     this.status = status;
-  }
-
-  public VoyageStatus getStatus() {
-    return status;
-  }
-
-  public void setStatus(VoyageStatus status) {
-    this.status = status;
-  }
-
-  public CreateVoyageRequest() {}
-
-  public String getVoyageNumber() {
-    return voyageNumber;
-  }
-
-  public void setVoyageNumber(String voyageNumber) {
-    this.voyageNumber = voyageNumber;
-  }
-
-  public Long getVesselId() {
-    return vesselId;
-  }
-
-  public void setVesselId(Long vesselId) {
-    this.vesselId = vesselId;
-  }
-
-  public Long getArrivalPortId() {
-    return arrivalPortId;
-  }
-
-  public void setArrivalPortId(Long arrivalId) {
-    this.arrivalPortId = arrivalId;
-  }
-
-  public LocalDateTime getDepartureTime() {
-    return departureTime;
-  }
-
-  public void setDepartureTime(LocalDateTime departureDate) {
-    this.departureTime = departureDate;
-  }
-
-  public LocalDateTime getArrivalTime() {
-    return arrivalTime;
-  }
-
-  public void setArrivalTime(LocalDateTime arrivalDate) {
-    this.arrivalTime = arrivalDate;
-  }
-
-  public Long getDeparturePortId() {
-    return departurePortId;
-  }
-
-  public void setDeparturePortId(Long departurePortId) {
-    this.departurePortId = departurePortId;
   }
 }

--- a/src/main/java/com/shipping/freightops/dto/CustomerResponse.java
+++ b/src/main/java/com/shipping/freightops/dto/CustomerResponse.java
@@ -2,7 +2,13 @@ package com.shipping.freightops.dto;
 
 import com.shipping.freightops.entity.Customer;
 import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+@Getter
+@Setter
+@NoArgsConstructor
 public class CustomerResponse {
   private Long id;
   private String companyName;
@@ -22,33 +28,5 @@ public class CustomerResponse {
     dto.address = customer.getAddress();
     dto.createdAt = customer.getCreatedAt();
     return dto;
-  }
-
-  public Long getId() {
-    return id;
-  }
-
-  public String getCompanyName() {
-    return companyName;
-  }
-
-  public String getContactName() {
-    return contactName;
-  }
-
-  public String getEmail() {
-    return email;
-  }
-
-  public String getPhone() {
-    return phone;
-  }
-
-  public String getAddress() {
-    return address;
-  }
-
-  public LocalDateTime getCreatedAt() {
-    return createdAt;
   }
 }

--- a/src/main/java/com/shipping/freightops/dto/FinancialSummaryResponse.java
+++ b/src/main/java/com/shipping/freightops/dto/FinancialSummaryResponse.java
@@ -2,7 +2,13 @@ package com.shipping.freightops.dto;
 
 import java.math.BigDecimal;
 import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+@Getter
+@Setter
+@NoArgsConstructor
 public class FinancialSummaryResponse {
   private String voyageNumber;
   private BigDecimal totalRevenueUsd;
@@ -26,29 +32,5 @@ public class FinancialSummaryResponse {
     response.orderCount = orderCount;
     response.owners = owners;
     return response;
-  }
-
-  public String getVoyageNumber() {
-    return voyageNumber;
-  }
-
-  public BigDecimal getTotalRevenueUsd() {
-    return totalRevenueUsd;
-  }
-
-  public BigDecimal getTotalCostsUsd() {
-    return totalCostsUsd;
-  }
-
-  public BigDecimal getNetProfitUsd() {
-    return netProfitUsd;
-  }
-
-  public int getOrderCount() {
-    return orderCount;
-  }
-
-  public List<OwnerFinancialShareResponse> getOwners() {
-    return owners;
   }
 }

--- a/src/main/java/com/shipping/freightops/dto/FreightOrderResponse.java
+++ b/src/main/java/com/shipping/freightops/dto/FreightOrderResponse.java
@@ -4,8 +4,14 @@ import com.shipping.freightops.entity.FreightOrder;
 import com.shipping.freightops.enums.OrderStatus;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 /** Read-only view of a freight order returned by the API. */
+@Getter
+@Setter
+@NoArgsConstructor
 public class FreightOrderResponse {
 
   private Long id;
@@ -43,65 +49,5 @@ public class FreightOrderResponse {
     dto.basePriceUsd = order.getBasePriceUsd();
     dto.discountReason = order.getDiscountReason();
     return dto;
-  }
-
-  public Long getId() {
-    return id;
-  }
-
-  public String getVoyageNumber() {
-    return voyageNumber;
-  }
-
-  public String getContainerCode() {
-    return containerCode;
-  }
-
-  public Long getAgentId() {
-    return agentId;
-  }
-
-  public String getAgentName() {
-    return agentName;
-  }
-
-  public String getCustomerName() {
-    return customerName;
-  }
-
-  public String getCustomerEmail() {
-    return customerEmail;
-  }
-
-  public String getOrderedBy() {
-    return orderedBy;
-  }
-
-  public String getNotes() {
-    return notes;
-  }
-
-  public OrderStatus getStatus() {
-    return status;
-  }
-
-  public LocalDateTime getCreatedAt() {
-    return createdAt;
-  }
-
-  public BigDecimal getBasePriceUsd() {
-    return basePriceUsd;
-  }
-
-  public BigDecimal getDiscountPercent() {
-    return discountPercent;
-  }
-
-  public BigDecimal getFinalPrice() {
-    return finalPrice;
-  }
-
-  public String getDiscountReason() {
-    return discountReason;
   }
 }

--- a/src/main/java/com/shipping/freightops/dto/LoadSummaryResponse.java
+++ b/src/main/java/com/shipping/freightops/dto/LoadSummaryResponse.java
@@ -1,7 +1,13 @@
 package com.shipping.freightops.dto;
 
 import com.shipping.freightops.entity.Voyage;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+@Getter
+@Setter
+@NoArgsConstructor
 public class LoadSummaryResponse {
   private String voyageNumber;
   private int maxCapacityTeu;
@@ -25,29 +31,5 @@ public class LoadSummaryResponse {
   private static double calculateUtilization(int current, int max) {
     if (max == 0) return 0.0;
     return Math.round((current * 1000.0) / max) / 10.0;
-  }
-
-  public String getVoyageNumber() {
-    return voyageNumber;
-  }
-
-  public int getMaxCapacityTeu() {
-    return maxCapacityTeu;
-  }
-
-  public int getCurrentLoadTeu() {
-    return currentLoadTeu;
-  }
-
-  public double getUtilizationPercent() {
-    return utilizationPercent;
-  }
-
-  public boolean isBookingOpen() {
-    return bookingOpen;
-  }
-
-  public int getContainerCount() {
-    return containerCount;
   }
 }

--- a/src/main/java/com/shipping/freightops/dto/MaritimeNewsArticle.java
+++ b/src/main/java/com/shipping/freightops/dto/MaritimeNewsArticle.java
@@ -1,57 +1,29 @@
 package com.shipping.freightops.dto;
 
 import java.time.LocalDate;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 /**
  * Represents a maritime news article used for shipping risk analysis and freight pricing decisions.
  * Contains headline, source, publication date, and summary information relevant to maritime
  * operations.
  */
+@Getter
+@Setter
+@NoArgsConstructor
 public class MaritimeNewsArticle {
   private String headline;
   private String source;
   private LocalDate publishedDate;
   private String summary;
 
-  public MaritimeNewsArticle() {}
-
   public MaritimeNewsArticle(
       String headline, String source, LocalDate publishedDate, String summary) {
     this.headline = headline;
     this.source = source;
     this.publishedDate = publishedDate;
-    this.summary = summary;
-  }
-
-  public String getHeadline() {
-    return headline;
-  }
-
-  public void setHeadline(String headline) {
-    this.headline = headline;
-  }
-
-  public String getSource() {
-    return source;
-  }
-
-  public void setSource(String source) {
-    this.source = source;
-  }
-
-  public LocalDate getPublishedDate() {
-    return publishedDate;
-  }
-
-  public void setPublishedDate(LocalDate publishedDate) {
-    this.publishedDate = publishedDate;
-  }
-
-  public String getSummary() {
-    return summary;
-  }
-
-  public void setSummary(String summary) {
     this.summary = summary;
   }
 }

--- a/src/main/java/com/shipping/freightops/dto/OrderTrackingResponse.java
+++ b/src/main/java/com/shipping/freightops/dto/OrderTrackingResponse.java
@@ -9,7 +9,13 @@ import com.shipping.freightops.enums.VoyageStatus;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+@Getter
+@Setter
+@NoArgsConstructor
 public class OrderTrackingResponse {
   private Long orderId;
   private OrderStatus status;
@@ -43,61 +49,5 @@ public class OrderTrackingResponse {
       dto.voyageStatus = order.getVoyage().getStatus();
     }
     return dto;
-  }
-
-  public void setEvents(List<TrackingEvent> events) {
-    this.events = events;
-  }
-
-  public List<TrackingEvent> getEvents() {
-    return events;
-  }
-
-  public String getVoyageNumber() {
-    return voyageNumber;
-  }
-
-  public String getVesselName() {
-    return vesselName;
-  }
-
-  public String getDeparturePort() {
-    return departurePort;
-  }
-
-  public String getArrivalPort() {
-    return arrivalPort;
-  }
-
-  public LocalDateTime getDepartureTime() {
-    return departureTime;
-  }
-
-  public LocalDateTime getEstimatedArrival() {
-    return estimatedArrival;
-  }
-
-  public VoyageStatus getVoyageStatus() {
-    return voyageStatus;
-  }
-
-  public Long getOrderId() {
-    return orderId;
-  }
-
-  public OrderStatus getStatus() {
-    return status;
-  }
-
-  public String getContainerCode() {
-    return ContainerCode;
-  }
-
-  public ContainerSize getContainerSize() {
-    return containerSize;
-  }
-
-  public ContainerType getContainerType() {
-    return containerType;
   }
 }

--- a/src/main/java/com/shipping/freightops/dto/OwnerFinancialShareResponse.java
+++ b/src/main/java/com/shipping/freightops/dto/OwnerFinancialShareResponse.java
@@ -1,7 +1,13 @@
 package com.shipping.freightops.dto;
 
 import java.math.BigDecimal;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+@Getter
+@Setter
+@NoArgsConstructor
 public class OwnerFinancialShareResponse {
   private String ownerName;
   private BigDecimal sharePercent;
@@ -22,25 +28,5 @@ public class OwnerFinancialShareResponse {
     response.costShareUsd = costShareUsd;
     response.profitShareUsd = profitShareUsd;
     return response;
-  }
-
-  public String getOwnerName() {
-    return ownerName;
-  }
-
-  public BigDecimal getSharePercent() {
-    return sharePercent;
-  }
-
-  public BigDecimal getRevenueShareUsd() {
-    return revenueShareUsd;
-  }
-
-  public BigDecimal getCostShareUsd() {
-    return costShareUsd;
-  }
-
-  public BigDecimal getProfitShareUsd() {
-    return profitShareUsd;
   }
 }

--- a/src/main/java/com/shipping/freightops/dto/PageResponse.java
+++ b/src/main/java/com/shipping/freightops/dto/PageResponse.java
@@ -1,8 +1,14 @@
 package com.shipping.freightops.dto;
 
 import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.springframework.data.domain.Page;
 
+@Getter
+@Setter
+@NoArgsConstructor
 public class PageResponse<T> {
   private List<T> content;
   private int page;
@@ -26,25 +32,5 @@ public class PageResponse<T> {
         page.getSize(),
         page.getTotalElements(),
         page.getTotalPages());
-  }
-
-  public List<T> getContent() {
-    return content;
-  }
-
-  public int getPage() {
-    return page;
-  }
-
-  public int getSize() {
-    return size;
-  }
-
-  public long getTotalElements() {
-    return totalElements;
-  }
-
-  public int getTotalPages() {
-    return totalPages;
   }
 }

--- a/src/main/java/com/shipping/freightops/dto/PortResponse.java
+++ b/src/main/java/com/shipping/freightops/dto/PortResponse.java
@@ -2,8 +2,14 @@ package com.shipping.freightops.dto;
 
 import com.shipping.freightops.entity.Port;
 import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 /** Read-only view of a port returned by the API. */
+@Getter
+@Setter
+@NoArgsConstructor
 public class PortResponse {
 
   private Long id;
@@ -21,25 +27,5 @@ public class PortResponse {
     dto.country = port.getCountry();
     dto.createdAt = port.getCreatedAt();
     return dto;
-  }
-
-  public Long getId() {
-    return id;
-  }
-
-  public String getUnlocode() {
-    return unlocode;
-  }
-
-  public String getName() {
-    return name;
-  }
-
-  public String getCountry() {
-    return country;
-  }
-
-  public LocalDateTime getCreatedAt() {
-    return createdAt;
   }
 }

--- a/src/main/java/com/shipping/freightops/dto/PriceSuggestionResponse.java
+++ b/src/main/java/com/shipping/freightops/dto/PriceSuggestionResponse.java
@@ -6,7 +6,13 @@ import com.shipping.freightops.enums.PriceSuggestionConfidence;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+@Getter
+@Setter
+@NoArgsConstructor
 public class PriceSuggestionResponse {
   private String voyageNumber;
   private String route;
@@ -21,37 +27,9 @@ public class PriceSuggestionResponse {
   private BigDecimal historicalMaxUsd;
   private List<RiskFactor> riskFactors;
 
-  public String getVoyageNumber() {
-    return voyageNumber;
-  }
-
-  public void setVoyageNumber(String voyageNumber) {
-    this.voyageNumber = voyageNumber;
-  }
-
-  public String getRoute() {
-    return route;
-  }
-
-  public void setRoute(String route) {
-    this.route = route;
-  }
-
-  public ContainerSize getContainerSize() {
-    return containerSize;
-  }
-
-  public void setContainerSize(ContainerSize containerSize) {
-    this.containerSize = containerSize;
-  }
-
   @JsonProperty("suggestedPriceLowUsd")
   public BigDecimal getSuggestedPriceLowUsd() {
     return suggestedPriceLowUsd;
-  }
-
-  public void setSuggestedPriceLowUsd(BigDecimal suggestedPriceLowUsd) {
-    this.suggestedPriceLowUsd = suggestedPriceLowUsd;
   }
 
   @JsonProperty("suggestedPriceHighUsd")
@@ -59,41 +37,9 @@ public class PriceSuggestionResponse {
     return suggestedPriceHighUsd;
   }
 
-  public void setSuggestedPriceHighUsd(BigDecimal suggestedPriceHighUsd) {
-    this.suggestedPriceHighUsd = suggestedPriceHighUsd;
-  }
-
-  public PriceSuggestionConfidence getConfidence() {
-    return confidence;
-  }
-
-  public void setConfidence(PriceSuggestionConfidence confidence) {
-    this.confidence = confidence;
-  }
-
-  public String getReasoning() {
-    return reasoning;
-  }
-
-  public void setReasoning(String reasoning) {
-    this.reasoning = reasoning;
-  }
-
-  public int getDataPoints() {
-    return dataPoints;
-  }
-
-  public void setDataPoints(int dataPoints) {
-    this.dataPoints = dataPoints;
-  }
-
   @JsonProperty("historicalAvgUsd")
   public BigDecimal getHistoricalAvgUsd() {
     return historicalAvgUsd;
-  }
-
-  public void setHistoricalAvgUsd(BigDecimal historicalAvgUsd) {
-    this.historicalAvgUsd = historicalAvgUsd;
   }
 
   @JsonProperty("historicalMinUsd")
@@ -101,25 +47,9 @@ public class PriceSuggestionResponse {
     return historicalMinUsd;
   }
 
-  public void setHistoricalMinUsd(BigDecimal historicalMinUsd) {
-    this.historicalMinUsd = historicalMinUsd;
-  }
-
   @JsonProperty("historicalMaxUsd")
   public BigDecimal getHistoricalMaxUsd() {
     return historicalMaxUsd;
-  }
-
-  public void setHistoricalMaxUsd(BigDecimal historicalMaxUsd) {
-    this.historicalMaxUsd = historicalMaxUsd;
-  }
-
-  public List<RiskFactor> getRiskFactors() {
-    return riskFactors;
-  }
-
-  public void setRiskFactors(List<RiskFactor> riskFactors) {
-    this.riskFactors = riskFactors;
   }
 
   /** Creates a fallback response for no-data or parse-failure scenarios. */

--- a/src/main/java/com/shipping/freightops/dto/RiskFactor.java
+++ b/src/main/java/com/shipping/freightops/dto/RiskFactor.java
@@ -1,41 +1,21 @@
 package com.shipping.freightops.dto;
 
 import com.shipping.freightops.enums.RiskImpact;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+@Getter
+@Setter
+@NoArgsConstructor
 public class RiskFactor {
   private String factor;
   private RiskImpact impact;
   private String description;
 
-  public RiskFactor() {}
-
   public RiskFactor(String factor, RiskImpact impact, String description) {
     this.factor = factor;
     this.impact = impact;
-    this.description = description;
-  }
-
-  public String getFactor() {
-    return factor;
-  }
-
-  public void setFactor(String factor) {
-    this.factor = factor;
-  }
-
-  public RiskImpact getImpact() {
-    return impact;
-  }
-
-  public void setImpact(RiskImpact impact) {
-    this.impact = impact;
-  }
-
-  public String getDescription() {
-    return description;
-  }
-
-  public void setDescription(String description) {
     this.description = description;
   }
 }

--- a/src/main/java/com/shipping/freightops/dto/TrackingEventRequest.java
+++ b/src/main/java/com/shipping/freightops/dto/TrackingEventRequest.java
@@ -3,7 +3,13 @@ package com.shipping.freightops.dto;
 import com.shipping.freightops.enums.EventType;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+@Getter
+@Setter
+@NoArgsConstructor
 public class TrackingEventRequest {
   @NotNull private EventType eventType;
 
@@ -13,45 +19,11 @@ public class TrackingEventRequest {
   private String location;
   private String performedBy;
 
-  public TrackingEventRequest() {}
-
   public TrackingEventRequest(
       EventType eventType, String description, String location, String performedBy) {
     this.eventType = eventType;
     this.description = description;
     this.location = location;
-    this.performedBy = performedBy;
-  }
-
-  public EventType getEventType() {
-    return eventType;
-  }
-
-  public void setEventType(EventType eventType) {
-    this.eventType = eventType;
-  }
-
-  public String getDescription() {
-    return description;
-  }
-
-  public void setDescription(String description) {
-    this.description = description;
-  }
-
-  public String getLocation() {
-    return location;
-  }
-
-  public void setLocation(String location) {
-    this.location = location;
-  }
-
-  public String getPerformedBy() {
-    return performedBy;
-  }
-
-  public void setPerformedBy(String performedBy) {
     this.performedBy = performedBy;
   }
 }

--- a/src/main/java/com/shipping/freightops/dto/UpdateDiscountRequest.java
+++ b/src/main/java/com/shipping/freightops/dto/UpdateDiscountRequest.java
@@ -5,7 +5,13 @@ import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.math.BigDecimal;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+@Getter
+@Setter
+@NoArgsConstructor
 public class UpdateDiscountRequest {
   @NotNull(message = "discountPercent is required")
   @DecimalMin(value = "0", inclusive = true)
@@ -14,20 +20,4 @@ public class UpdateDiscountRequest {
 
   @NotBlank(message = "Reason is required")
   private String reason;
-
-  public BigDecimal getDiscountPercent() {
-    return discountPercent;
-  }
-
-  public void setDiscountPercent(BigDecimal discountPercent) {
-    this.discountPercent = discountPercent;
-  }
-
-  public String getReason() {
-    return reason;
-  }
-
-  public void setReason(String reason) {
-    this.reason = reason;
-  }
 }

--- a/src/main/java/com/shipping/freightops/dto/VesselOwnerResponse.java
+++ b/src/main/java/com/shipping/freightops/dto/VesselOwnerResponse.java
@@ -3,8 +3,14 @@ package com.shipping.freightops.dto;
 import com.shipping.freightops.entity.VesselOwner;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 /** Read-only view of a vessel owner returned by the API. */
+@Getter
+@Setter
+@NoArgsConstructor
 public class VesselOwnerResponse {
 
   private Long id;
@@ -24,29 +30,5 @@ public class VesselOwnerResponse {
     dto.createdAt = owner.getCreatedAt();
     dto.updatedAt = owner.getUpdatedAt();
     return dto;
-  }
-
-  public Long getId() {
-    return id;
-  }
-
-  public String getOwnerName() {
-    return ownerName;
-  }
-
-  public String getOwnerEmail() {
-    return ownerEmail;
-  }
-
-  public BigDecimal getSharePercent() {
-    return sharePercent;
-  }
-
-  public LocalDateTime getCreatedAt() {
-    return createdAt;
-  }
-
-  public LocalDateTime getUpdatedAt() {
-    return updatedAt;
   }
 }

--- a/src/main/java/com/shipping/freightops/dto/VesselResponse.java
+++ b/src/main/java/com/shipping/freightops/dto/VesselResponse.java
@@ -1,8 +1,14 @@
 package com.shipping.freightops.dto;
 
 import com.shipping.freightops.entity.Vessel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 /** Read-only view of a vessel returned by the API. */
+@Getter
+@Setter
+@NoArgsConstructor
 public class VesselResponse {
   private String name;
   private String imoNumber;
@@ -15,17 +21,5 @@ public class VesselResponse {
     dto.capacityTeu = vessel.getCapacityTeu();
     dto.imoNumber = vessel.getImoNumber();
     return dto;
-  }
-
-  public String getName() {
-    return name;
-  }
-
-  public String getImoNumber() {
-    return imoNumber;
-  }
-
-  public int getCapacityTeu() {
-    return capacityTeu;
   }
 }

--- a/src/main/java/com/shipping/freightops/dto/VoyageContainerResponse.java
+++ b/src/main/java/com/shipping/freightops/dto/VoyageContainerResponse.java
@@ -4,7 +4,13 @@ import com.shipping.freightops.entity.FreightOrder;
 import com.shipping.freightops.enums.ContainerSize;
 import com.shipping.freightops.enums.ContainerType;
 import com.shipping.freightops.enums.OrderStatus;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+@Getter
+@Setter
+@NoArgsConstructor
 public class VoyageContainerResponse {
 
   private String containerCode;
@@ -21,25 +27,5 @@ public class VoyageContainerResponse {
     dto.orderedBy = order.getOrderedBy();
     dto.orderStatus = order.getStatus();
     return dto;
-  }
-
-  public String getContainerCode() {
-    return containerCode;
-  }
-
-  public ContainerSize getContainerSize() {
-    return containerSize;
-  }
-
-  public ContainerType getContainerType() {
-    return containerType;
-  }
-
-  public String getOrderedBy() {
-    return orderedBy;
-  }
-
-  public OrderStatus getOrderStatus() {
-    return orderStatus;
   }
 }

--- a/src/main/java/com/shipping/freightops/dto/VoyageCostResponse.java
+++ b/src/main/java/com/shipping/freightops/dto/VoyageCostResponse.java
@@ -3,7 +3,13 @@ package com.shipping.freightops.dto;
 import com.shipping.freightops.entity.VoyageCost;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+@Getter
+@Setter
+@NoArgsConstructor
 public class VoyageCostResponse {
   private Long id;
   private Long voyageId;
@@ -21,29 +27,5 @@ public class VoyageCostResponse {
     dto.createdAt = entity.getCreatedAt();
     dto.updatedAt = entity.getUpdatedAt();
     return dto;
-  }
-
-  public Long getId() {
-    return id;
-  }
-
-  public Long getVoyageId() {
-    return voyageId;
-  }
-
-  public String getDescription() {
-    return description;
-  }
-
-  public BigDecimal getAmountUsd() {
-    return amountUsd;
-  }
-
-  public LocalDateTime getCreatedAt() {
-    return createdAt;
-  }
-
-  public LocalDateTime getUpdatedAt() {
-    return updatedAt;
   }
 }

--- a/src/main/java/com/shipping/freightops/dto/VoyagePriceRequest.java
+++ b/src/main/java/com/shipping/freightops/dto/VoyagePriceRequest.java
@@ -4,26 +4,16 @@ import com.shipping.freightops.enums.ContainerSize;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import java.math.BigDecimal;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+@Getter
+@Setter
+@NoArgsConstructor
 public class VoyagePriceRequest {
 
   @NotNull private ContainerSize containerSize;
 
   @NotNull @Positive private BigDecimal basePriceUsd;
-
-  public ContainerSize getContainerSize() {
-    return containerSize;
-  }
-
-  public void setContainerSize(ContainerSize containerSize) {
-    this.containerSize = containerSize;
-  }
-
-  public BigDecimal getBasePriceUsd() {
-    return basePriceUsd;
-  }
-
-  public void setBasePriceUsd(BigDecimal basePriceUsd) {
-    this.basePriceUsd = basePriceUsd;
-  }
 }

--- a/src/main/java/com/shipping/freightops/dto/VoyagePriceResponse.java
+++ b/src/main/java/com/shipping/freightops/dto/VoyagePriceResponse.java
@@ -4,7 +4,13 @@ import com.shipping.freightops.entity.VoyagePrice;
 import com.shipping.freightops.enums.ContainerSize;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+@Getter
+@Setter
+@NoArgsConstructor
 public class VoyagePriceResponse {
   private Long voyageId;
   private ContainerSize containerSize;
@@ -18,21 +24,5 @@ public class VoyagePriceResponse {
     dto.basePriceUsd = entity.getBasePriceUsd();
     dto.createdAt = entity.getCreatedAt();
     return dto;
-  }
-
-  public Long getVoyageId() {
-    return voyageId;
-  }
-
-  public ContainerSize getContainerSize() {
-    return containerSize;
-  }
-
-  public BigDecimal getBasePriceUsd() {
-    return basePriceUsd;
-  }
-
-  public LocalDateTime getCreatedAt() {
-    return createdAt;
   }
 }

--- a/src/main/java/com/shipping/freightops/dto/VoyageResponse.java
+++ b/src/main/java/com/shipping/freightops/dto/VoyageResponse.java
@@ -5,7 +5,13 @@ import com.shipping.freightops.enums.VoyageStatus;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+@Getter
+@Setter
+@NoArgsConstructor
 public class VoyageResponse {
   private String voyageNumber;
   private String vesselName;
@@ -40,77 +46,5 @@ public class VoyageResponse {
           responses.add(response);
         });
     return responses;
-  }
-
-  public String getVoyageNumber() {
-    return voyageNumber;
-  }
-
-  public void setVoyageNumber(String voyageNumber) {
-    this.voyageNumber = voyageNumber;
-  }
-
-  public String getVesselName() {
-    return vesselName;
-  }
-
-  public void setVesselName(String vesselName) {
-    this.vesselName = vesselName;
-  }
-
-  public String getDeparturePortName() {
-    return departurePortName;
-  }
-
-  public void setDeparturePortName(String departurePortName) {
-    this.departurePortName = departurePortName;
-  }
-
-  public String getArrivalPortName() {
-    return arrivalPortName;
-  }
-
-  public void setArrivalPortName(String arrivalPortName) {
-    this.arrivalPortName = arrivalPortName;
-  }
-
-  public LocalDateTime getDepartureDate() {
-    return departureTime;
-  }
-
-  public void setDepartureDate(LocalDateTime departureTime) {
-    this.departureTime = departureTime;
-  }
-
-  public LocalDateTime getArrivalDate() {
-    return arrivalTime;
-  }
-
-  public void setArrivalDate(LocalDateTime arrivalTime) {
-    this.arrivalTime = arrivalTime;
-  }
-
-  public boolean isBookingOpen() {
-    return bookingOpen;
-  }
-
-  public void setBookingOpen(boolean bookingOpen) {
-    this.bookingOpen = bookingOpen;
-  }
-
-  public int getMaxCapacityTeu() {
-    return maxCapacityTeu;
-  }
-
-  public void setMaxCapacityTeu(int maxCapacityTeu) {
-    this.maxCapacityTeu = maxCapacityTeu;
-  }
-
-  public VoyageStatus getStatus() {
-    return status;
-  }
-
-  public void setStatus(VoyageStatus status) {
-    this.status = status;
   }
 }

--- a/src/main/java/com/shipping/freightops/dto/VoyageTrackingResponse.java
+++ b/src/main/java/com/shipping/freightops/dto/VoyageTrackingResponse.java
@@ -3,7 +3,13 @@ package com.shipping.freightops.dto;
 import com.shipping.freightops.entity.Voyage;
 import com.shipping.freightops.enums.VoyageStatus;
 import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+@Getter
+@Setter
+@NoArgsConstructor
 public class VoyageTrackingResponse {
   private String voyageNumber;
   private VoyageStatus status;
@@ -21,29 +27,5 @@ public class VoyageTrackingResponse {
     dto.departureTime = voyage.getDepartureTime();
     dto.arrivalTime = voyage.getArrivalTime();
     return dto;
-  }
-
-  public String getVoyageNumber() {
-    return voyageNumber;
-  }
-
-  public VoyageStatus getStatus() {
-    return status;
-  }
-
-  public String getDeparturePort() {
-    return departurePort;
-  }
-
-  public String getArrivalPort() {
-    return arrivalPort;
-  }
-
-  public LocalDateTime getDepartureTime() {
-    return departureTime;
-  }
-
-  public LocalDateTime getArrivalTime() {
-    return arrivalTime;
   }
 }

--- a/src/main/java/com/shipping/freightops/entity/Agent.java
+++ b/src/main/java/com/shipping/freightops/entity/Agent.java
@@ -8,7 +8,13 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.math.BigDecimal;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+@Getter
+@Setter
+@NoArgsConstructor
 @Entity
 @Table(name = "agents")
 public class Agent extends BaseEntity {
@@ -35,46 +41,4 @@ public class Agent extends BaseEntity {
 
   @Column(nullable = false)
   private boolean active = true;
-
-  // Getters & Setters
-
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  public String getEmail() {
-    return email;
-  }
-
-  public void setEmail(String email) {
-    this.email = email;
-  }
-
-  public BigDecimal getCommissionPercent() {
-    return commissionPercent;
-  }
-
-  public void setCommissionPercent(BigDecimal commissionPercent) {
-    this.commissionPercent = commissionPercent;
-  }
-
-  public AgentType getType() {
-    return type;
-  }
-
-  public void setType(AgentType type) {
-    this.type = type;
-  }
-
-  public boolean isActive() {
-    return active;
-  }
-
-  public void setActive(boolean active) {
-    this.active = active;
-  }
 }

--- a/src/main/java/com/shipping/freightops/entity/BaseEntity.java
+++ b/src/main/java/com/shipping/freightops/entity/BaseEntity.java
@@ -8,8 +8,14 @@ import jakarta.persistence.MappedSuperclass;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
 import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 /** Shared audit fields for all entities. */
+@Getter
+@Setter
+@NoArgsConstructor
 @MappedSuperclass
 public abstract class BaseEntity {
 
@@ -32,21 +38,5 @@ public abstract class BaseEntity {
   @PreUpdate
   protected void onUpdate() {
     updatedAt = LocalDateTime.now();
-  }
-
-  public Long getId() {
-    return id;
-  }
-
-  public void setId(Long id) {
-    this.id = id;
-  }
-
-  public LocalDateTime getCreatedAt() {
-    return createdAt;
-  }
-
-  public LocalDateTime getUpdatedAt() {
-    return updatedAt;
   }
 }

--- a/src/main/java/com/shipping/freightops/entity/Container.java
+++ b/src/main/java/com/shipping/freightops/entity/Container.java
@@ -5,8 +5,14 @@ import com.shipping.freightops.enums.ContainerType;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 /** A shipping container identified by its BIC code (e.g. MSCU1234567). */
+@Getter
+@Setter
+@NoArgsConstructor
 @Entity
 @Table(name = "containers")
 public class Container extends BaseEntity {
@@ -29,8 +35,6 @@ public class Container extends BaseEntity {
   @Column(nullable = false)
   private int teu;
 
-  public Container() {}
-
   public Container(String containerCode, ContainerSize size, ContainerType type) {
     this.containerCode = containerCode;
     this.size = size;
@@ -38,32 +42,8 @@ public class Container extends BaseEntity {
     this.teu = size.getTeu();
   }
 
-  public String getContainerCode() {
-    return containerCode;
-  }
-
-  public void setContainerCode(String containerCode) {
-    this.containerCode = containerCode;
-  }
-
-  public ContainerSize getSize() {
-    return size;
-  }
-
   public void setSize(ContainerSize size) {
     this.size = size;
     this.teu = size.getTeu();
-  }
-
-  public ContainerType getType() {
-    return type;
-  }
-
-  public void setType(ContainerType type) {
-    this.type = type;
-  }
-
-  public int getTeu() {
-    return teu;
   }
 }

--- a/src/main/java/com/shipping/freightops/entity/Customer.java
+++ b/src/main/java/com/shipping/freightops/entity/Customer.java
@@ -5,7 +5,13 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+@Getter
+@Setter
+@NoArgsConstructor
 @Entity
 @Table(name = "customers")
 public class Customer extends BaseEntity {
@@ -27,51 +33,9 @@ public class Customer extends BaseEntity {
 
   private String address;
 
-  public Customer() {}
-
   public Customer(String companyName, String contactName, String email) {
     this.companyName = companyName;
     this.contactName = contactName;
     this.email = email;
-  }
-
-  public String getCompanyName() {
-    return companyName;
-  }
-
-  public void setCompanyName(String companyName) {
-    this.companyName = companyName;
-  }
-
-  public String getContactName() {
-    return contactName;
-  }
-
-  public void setContactName(String contactName) {
-    this.contactName = contactName;
-  }
-
-  public String getEmail() {
-    return email;
-  }
-
-  public void setEmail(String email) {
-    this.email = email;
-  }
-
-  public String getPhone() {
-    return phone;
-  }
-
-  public void setPhone(String phone) {
-    this.phone = phone;
-  }
-
-  public String getAddress() {
-    return address;
-  }
-
-  public void setAddress(String address) {
-    this.address = address;
   }
 }

--- a/src/main/java/com/shipping/freightops/entity/FreightOrder.java
+++ b/src/main/java/com/shipping/freightops/entity/FreightOrder.java
@@ -6,8 +6,14 @@ import jakarta.validation.constraints.*;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 /** A freight booking made by the internal ops team, assigning a container to a voyage. */
+@Getter
+@Setter
+@NoArgsConstructor
 @Entity
 @Table(name = "freight_orders")
 public class FreightOrder extends BaseEntity {
@@ -67,102 +73,4 @@ public class FreightOrder extends BaseEntity {
 
   @Column(nullable = true, length = 500)
   private String discountReason;
-
-  public FreightOrder() {}
-
-  public void setEvents(List<TrackingEvent> events) {
-    this.events = events;
-  }
-
-  public List<TrackingEvent> getEvents() {
-    return events;
-  }
-
-  public String getOrderedBy() {
-    return orderedBy;
-  }
-
-  public void setOrderedBy(String orderedBy) {
-    this.orderedBy = orderedBy;
-  }
-
-  public Customer getCustomer() {
-    return customer;
-  }
-
-  public void setCustomer(Customer customer) {
-    this.customer = customer;
-  }
-
-  public Voyage getVoyage() {
-    return voyage;
-  }
-
-  public void setVoyage(Voyage voyage) {
-    this.voyage = voyage;
-  }
-
-  public Container getContainer() {
-    return container;
-  }
-
-  public void setContainer(Container container) {
-    this.container = container;
-  }
-
-  public Agent getAgent() {
-    return agent;
-  }
-
-  public void setAgent(Agent agent) {
-    this.agent = agent;
-  }
-
-  public String getNotes() {
-    return notes;
-  }
-
-  public void setNotes(String notes) {
-    this.notes = notes;
-  }
-
-  public OrderStatus getStatus() {
-    return status;
-  }
-
-  public void setStatus(OrderStatus status) {
-    this.status = status;
-  }
-
-  public BigDecimal getBasePriceUsd() {
-    return basePriceUsd;
-  }
-
-  public void setBasePriceUsd(BigDecimal basePriceUsd) {
-    this.basePriceUsd = basePriceUsd;
-  }
-
-  public BigDecimal getDiscountPercent() {
-    return discountPercent;
-  }
-
-  public void setDiscountPercent(BigDecimal discountPercent) {
-    this.discountPercent = discountPercent;
-  }
-
-  public BigDecimal getFinalPrice() {
-    return finalPrice;
-  }
-
-  public void setFinalPrice(BigDecimal finalPrice) {
-    this.finalPrice = finalPrice;
-  }
-
-  public String getDiscountReason() {
-    return discountReason;
-  }
-
-  public void setDiscountReason(String discountReason) {
-    this.discountReason = discountReason;
-  }
 }

--- a/src/main/java/com/shipping/freightops/entity/Invoice.java
+++ b/src/main/java/com/shipping/freightops/entity/Invoice.java
@@ -1,29 +1,17 @@
 package com.shipping.freightops.entity;
 
 import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+@Getter
+@Setter
+@NoArgsConstructor
 @Entity
 public class Invoice {
   @Id private String id;
   @OneToOne private FreightOrder order;
-
-  public Invoice() {}
-
-  public String getId() {
-    return id;
-  }
-
-  public void setId(String id) {
-    this.id = id;
-  }
-
-  public FreightOrder getOrder() {
-    return order;
-  }
-
-  public void setOrder(FreightOrder order) {
-    this.order = order;
-  }
 
   public Invoice(FreightOrder order, String id) {
     this.id = id;

--- a/src/main/java/com/shipping/freightops/entity/Port.java
+++ b/src/main/java/com/shipping/freightops/entity/Port.java
@@ -5,8 +5,14 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 /** A port of call (e.g. AEJEA - Jebel Ali, Dubai). */
+@Getter
+@Setter
+@NoArgsConstructor
 @Entity
 @Table(name = "ports")
 public class Port extends BaseEntity {
@@ -24,35 +30,9 @@ public class Port extends BaseEntity {
   @Column(nullable = false)
   private String country;
 
-  public Port() {}
-
   public Port(String unlocode, String name, String country) {
     this.unlocode = unlocode;
     this.name = name;
-    this.country = country;
-  }
-
-  public String getUnlocode() {
-    return unlocode;
-  }
-
-  public void setUnlocode(String unlocode) {
-    this.unlocode = unlocode;
-  }
-
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  public String getCountry() {
-    return country;
-  }
-
-  public void setCountry(String country) {
     this.country = country;
   }
 }

--- a/src/main/java/com/shipping/freightops/entity/TrackingEvent.java
+++ b/src/main/java/com/shipping/freightops/entity/TrackingEvent.java
@@ -7,7 +7,13 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.ManyToOne;
 import jakarta.validation.constraints.NotBlank;
 import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+@Getter
+@Setter
+@NoArgsConstructor
 @Entity
 public class TrackingEvent extends BaseEntity {
   @ManyToOne(optional = false)
@@ -24,8 +30,6 @@ public class TrackingEvent extends BaseEntity {
   private String performedBy;
   private LocalDateTime eventTime;
 
-  public TrackingEvent() {}
-
   public TrackingEvent(
       FreightOrder freightOrder,
       EventType eventType,
@@ -37,54 +41,6 @@ public class TrackingEvent extends BaseEntity {
     this.description = description;
     this.location = location;
     this.performedBy = performedBy;
-    this.eventTime = eventTime;
-  }
-
-  public FreightOrder getFreightOrder() {
-    return freightOrder;
-  }
-
-  public void setFreightOrder(FreightOrder freightOrder) {
-    this.freightOrder = freightOrder;
-  }
-
-  public EventType getEventType() {
-    return eventType;
-  }
-
-  public void setEventType(EventType eventType) {
-    this.eventType = eventType;
-  }
-
-  public String getDescription() {
-    return description;
-  }
-
-  public void setDescription(String description) {
-    this.description = description;
-  }
-
-  public String getLocation() {
-    return location;
-  }
-
-  public void setLocation(String location) {
-    this.location = location;
-  }
-
-  public String getPerformedBy() {
-    return performedBy;
-  }
-
-  public void setPerformedBy(String performedBy) {
-    this.performedBy = performedBy;
-  }
-
-  public LocalDateTime getEventTime() {
-    return eventTime;
-  }
-
-  public void setEventTime(LocalDateTime eventTime) {
     this.eventTime = eventTime;
   }
 }

--- a/src/main/java/com/shipping/freightops/entity/Vessel.java
+++ b/src/main/java/com/shipping/freightops/entity/Vessel.java
@@ -5,8 +5,14 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Positive;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 /** A cargo vessel that carries containers between ports. */
+@Getter
+@Setter
+@NoArgsConstructor
 @Entity
 @Table(name = "vessels")
 public class Vessel extends BaseEntity {
@@ -25,35 +31,9 @@ public class Vessel extends BaseEntity {
   @Column(nullable = false)
   private int capacityTeu;
 
-  public Vessel() {}
-
   public Vessel(String name, String imoNumber, int capacityTeu) {
     this.name = name;
     this.imoNumber = imoNumber;
-    this.capacityTeu = capacityTeu;
-  }
-
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  public String getImoNumber() {
-    return imoNumber;
-  }
-
-  public void setImoNumber(String imoNumber) {
-    this.imoNumber = imoNumber;
-  }
-
-  public int getCapacityTeu() {
-    return capacityTeu;
-  }
-
-  public void setCapacityTeu(int capacityTeu) {
     this.capacityTeu = capacityTeu;
   }
 }

--- a/src/main/java/com/shipping/freightops/entity/VesselOwner.java
+++ b/src/main/java/com/shipping/freightops/entity/VesselOwner.java
@@ -11,10 +11,16 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.math.BigDecimal;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 
 /** An owner of a vessel with a fractional share used for cost/profit splitting. */
+@Getter
+@Setter
+@NoArgsConstructor
 @Entity
 @Table(name = "vessel_owners")
 public class VesselOwner extends BaseEntity {
@@ -39,38 +45,4 @@ public class VesselOwner extends BaseEntity {
   @DecimalMax(value = "100.00")
   @Column(nullable = false, precision = 5, scale = 2)
   private BigDecimal sharePercent;
-
-  public VesselOwner() {}
-
-  public Vessel getVessel() {
-    return vessel;
-  }
-
-  public void setVessel(Vessel vessel) {
-    this.vessel = vessel;
-  }
-
-  public String getOwnerName() {
-    return ownerName;
-  }
-
-  public void setOwnerName(String ownerName) {
-    this.ownerName = ownerName;
-  }
-
-  public String getOwnerEmail() {
-    return ownerEmail;
-  }
-
-  public void setOwnerEmail(String ownerEmail) {
-    this.ownerEmail = ownerEmail;
-  }
-
-  public BigDecimal getSharePercent() {
-    return sharePercent;
-  }
-
-  public void setSharePercent(BigDecimal sharePercent) {
-    this.sharePercent = sharePercent;
-  }
 }

--- a/src/main/java/com/shipping/freightops/entity/Voyage.java
+++ b/src/main/java/com/shipping/freightops/entity/Voyage.java
@@ -12,8 +12,14 @@ import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 /** A scheduled trip of a vessel from one port to another. */
+@Getter
+@Setter
+@NoArgsConstructor
 @Entity
 @Table(name = "voyages")
 public class Voyage extends BaseEntity {
@@ -54,78 +60,4 @@ public class Voyage extends BaseEntity {
   private int maxCapacityTeu;
 
   @Column private boolean bookingOpen;
-
-  public Voyage() {}
-
-  public String getVoyageNumber() {
-    return voyageNumber;
-  }
-
-  public void setVoyageNumber(String voyageNumber) {
-    this.voyageNumber = voyageNumber;
-  }
-
-  public Vessel getVessel() {
-    return vessel;
-  }
-
-  public void setVessel(Vessel vessel) {
-    this.vessel = vessel;
-  }
-
-  public Port getDeparturePort() {
-    return departurePort;
-  }
-
-  public void setDeparturePort(Port departurePort) {
-    this.departurePort = departurePort;
-  }
-
-  public Port getArrivalPort() {
-    return arrivalPort;
-  }
-
-  public void setArrivalPort(Port arrivalPort) {
-    this.arrivalPort = arrivalPort;
-  }
-
-  public LocalDateTime getDepartureTime() {
-    return departureTime;
-  }
-
-  public void setDepartureTime(LocalDateTime departureTime) {
-    this.departureTime = departureTime;
-  }
-
-  public LocalDateTime getArrivalTime() {
-    return arrivalTime;
-  }
-
-  public void setArrivalTime(LocalDateTime arrivalTime) {
-    this.arrivalTime = arrivalTime;
-  }
-
-  public VoyageStatus getStatus() {
-    return status;
-  }
-
-  public void setStatus(VoyageStatus status) {
-    this.status = status;
-  }
-
-  public int getMaxCapacityTeu() {
-    return maxCapacityTeu;
-  }
-
-  public void setMaxCapacityTeu(int maxCapacityTeu) {
-    this.maxCapacityTeu = maxCapacityTeu;
-  }
-
-  public boolean isBookingOpen() {
-    return bookingOpen;
-  }
-
-  public void setBookingOpen(boolean bookingOpen) {
-    this.bookingOpen = bookingOpen;
-  }
 }

--- a/src/main/java/com/shipping/freightops/entity/VoyageCost.java
+++ b/src/main/java/com/shipping/freightops/entity/VoyageCost.java
@@ -10,10 +10,16 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import java.math.BigDecimal;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 
 /** Cost line item associated with a voyage. */
+@Getter
+@Setter
+@NoArgsConstructor
 @Entity
 @Table(name = "voyage_costs")
 public class VoyageCost extends BaseEntity {
@@ -32,28 +38,4 @@ public class VoyageCost extends BaseEntity {
   @Positive
   @Column(nullable = false, precision = 12, scale = 2)
   private BigDecimal amountUsd;
-
-  public Voyage getVoyage() {
-    return voyage;
-  }
-
-  public void setVoyage(Voyage voyage) {
-    this.voyage = voyage;
-  }
-
-  public String getDescription() {
-    return description;
-  }
-
-  public void setDescription(String description) {
-    this.description = description;
-  }
-
-  public BigDecimal getAmountUsd() {
-    return amountUsd;
-  }
-
-  public void setAmountUsd(BigDecimal amountUsd) {
-    this.amountUsd = amountUsd;
-  }
 }

--- a/src/main/java/com/shipping/freightops/entity/VoyagePrice.java
+++ b/src/main/java/com/shipping/freightops/entity/VoyagePrice.java
@@ -5,7 +5,13 @@ import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import java.math.BigDecimal;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+@Getter
+@Setter
+@NoArgsConstructor
 @Entity
 @Table(
     name = "voyage_prices",
@@ -30,30 +36,4 @@ public class VoyagePrice extends BaseEntity {
   @Column(nullable = false, precision = 10, scale = 2)
   @Positive
   private BigDecimal basePriceUsd;
-
-  public VoyagePrice() {}
-
-  public Voyage getVoyage() {
-    return voyage;
-  }
-
-  public void setVoyage(Voyage voyage) {
-    this.voyage = voyage;
-  }
-
-  public ContainerSize getContainerSize() {
-    return containerSize;
-  }
-
-  public void setContainerSize(ContainerSize containerSize) {
-    this.containerSize = containerSize;
-  }
-
-  public BigDecimal getBasePriceUsd() {
-    return basePriceUsd;
-  }
-
-  public void setBasePriceUsd(BigDecimal basePriceUsd) {
-    this.basePriceUsd = basePriceUsd;
-  }
 }


### PR DESCRIPTION
Replace hand-written getters, setters, and no-arg constructors with @Getter, @Setter, and @NoArgsConstructor. @Data is intentionally avoided on @Entity classes to prevent JPA proxy issues.

VoyageResponse field names corrected: departureDate/arrivalDate renamed to departureTime/arrivalTime to match the underlying fields.

closes #26 