### PR TITLE
ENH-006 Add id to response DTOs and update tests

### DIFF
--- a/src/main/java/com/shipping/freightops/dto/VesselResponse.java
+++ b/src/main/java/com/shipping/freightops/dto/VesselResponse.java
@@ -10,6 +10,7 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 public class VesselResponse {
+  private Long id;
   private String name;
   private String imoNumber;
   private int capacityTeu;
@@ -17,6 +18,7 @@ public class VesselResponse {
   /** Factory method to map entity → response DTO. */
   public static VesselResponse fromEntity(Vessel vessel) {
     VesselResponse dto = new VesselResponse();
+    dto.id = vessel.getId();
     dto.name = vessel.getName();
     dto.capacityTeu = vessel.getCapacityTeu();
     dto.imoNumber = vessel.getImoNumber();

--- a/src/main/java/com/shipping/freightops/dto/VoyageResponse.java
+++ b/src/main/java/com/shipping/freightops/dto/VoyageResponse.java
@@ -13,6 +13,7 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 public class VoyageResponse {
+  private Long id;
   private String voyageNumber;
   private String vesselName;
   private String departurePortName;
@@ -25,6 +26,7 @@ public class VoyageResponse {
 
   // voyage response format
   public VoyageResponse(Voyage voyage) {
+    id = voyage.getId();
     voyageNumber = voyage.getVoyageNumber();
     vesselName = voyage.getVessel().getName();
     departurePortName = voyage.getDeparturePort().getName();

--- a/src/test/java/com/shipping/freightops/controller/VesselControllerTest.java
+++ b/src/test/java/com/shipping/freightops/controller/VesselControllerTest.java
@@ -61,6 +61,8 @@ public class VesselControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)))
         .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.id").exists())
+        .andExpect(jsonPath("$.id").isNotEmpty())
         .andExpect(jsonPath("$.name").value("MV Test"))
         .andExpect(jsonPath("$.imoNumber").value("8888888"))
         .andExpect(jsonPath("$.capacityTeu").value(3000));
@@ -119,6 +121,8 @@ public class VesselControllerTest {
     mockMvc
         .perform(get("/api/v1/vessels"))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$").isArray());
+        .andExpect(jsonPath("$").isArray())
+        .andExpect(jsonPath("$[0].id").exists())
+        .andExpect(jsonPath("$[0].id").isNotEmpty());
   }
 }

--- a/src/test/java/com/shipping/freightops/controller/VoyageControllerTest.java
+++ b/src/test/java/com/shipping/freightops/controller/VoyageControllerTest.java
@@ -108,7 +108,9 @@ public class VoyageControllerTest {
     mockMvc
         .perform(MockMvcRequestBuilders.get("/api/v1/voyages"))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$").isArray());
+        .andExpect(jsonPath("$").isArray())
+        .andExpect(jsonPath("$[0].id").exists())
+        .andExpect(jsonPath("$[0].id").isNotEmpty());
   }
 
   @Test
@@ -119,7 +121,9 @@ public class VoyageControllerTest {
             MockMvcRequestBuilders.get("/api/v1/voyages")
                 .param("status", voyage.getStatus().toString()))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$").isArray());
+        .andExpect(jsonPath("$").isArray())
+        .andExpect(jsonPath("$[0].id").exists())
+        .andExpect(jsonPath("$[0].id").isNotEmpty());
   }
 
   @Test
@@ -128,7 +132,9 @@ public class VoyageControllerTest {
     mockMvc
         .perform(MockMvcRequestBuilders.get("/api/v1/voyages/" + voyage.getId()))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$").isMap());
+        .andExpect(jsonPath("$").isMap())
+        .andExpect(jsonPath("$.id").exists())
+        .andExpect(jsonPath("$.id").isNotEmpty());
   }
 
   @Test
@@ -157,7 +163,9 @@ public class VoyageControllerTest {
             post("/api/v1/voyages")
                 .contentType("application/json")
                 .content(objectMapper.writeValueAsString(voyageRequest)))
-        .andExpect(status().isCreated());
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.id").exists())
+        .andExpect(jsonPath("$.id").isNotEmpty());
   }
 
   @Test


### PR DESCRIPTION
Adds id field to `VesselResponse` and `VoyageResponse` and maps it from the entity as required.
Updates controller tests to assert that id is present and non-null in both `POST` and `GET ` responses.
- [x] All tests pass.

Close #63 